### PR TITLE
HG-770 Fixing issue with using mark and sendPagePerformance together

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": [
     "/dist/weppy.amd.js",
     "/dist/weppy.cjs.js",

--- a/dist/weppy.amd.js
+++ b/dist/weppy.amd.js
@@ -13,7 +13,7 @@ define(["require", "exports"], function (require, exports) {
             "page": 'index',
             "context": {},
             "debug": false
-        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
+        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
             return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
         }, log = function () {
             if (options.debug) {
@@ -297,7 +297,7 @@ define(["require", "exports"], function (require, exports) {
                 this._namespace.send(2 /* Timer */, name, duration, annotations);
             };
             NamespaceTimer.prototype.start = function (name, annotations) {
-                this.PARTIALS[name] = [timeSinceInit(), annotations];
+                this.PARTIALS[name] = [timestamp(), annotations];
                 return new Timer(this, name);
             };
             NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -306,7 +306,7 @@ define(["require", "exports"], function (require, exports) {
                     logError("Timer " + name + " ended without having been started");
                     return;
                 }
-                duration = timeSinceInit() - this.PARTIALS[name][0];
+                duration = timestamp() - this.PARTIALS[name][0];
                 annotations = extend(annotations, this.PARTIALS[name][1]);
                 this.PARTIALS[name] = false;
                 this.send(name, duration, annotations);
@@ -340,12 +340,8 @@ define(["require", "exports"], function (require, exports) {
                     return self.timeSync(name, action, scope || this, arguments, annotations);
                 };
             };
-            /**
-             * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
-             */
             NamespaceTimer.prototype.mark = function (name, annotations) {
-                var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
-                this.send(name, time, annotations);
+                this.send(name, timestamp(), annotations);
             };
             return NamespaceTimer;
         })();

--- a/dist/weppy.amd.js
+++ b/dist/weppy.amd.js
@@ -13,7 +13,7 @@ define(["require", "exports"], function (require, exports) {
             "page": 'index',
             "context": {},
             "debug": false
-        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
             return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
         }, log = function () {
             if (options.debug) {
@@ -297,7 +297,7 @@ define(["require", "exports"], function (require, exports) {
                 this._namespace.send(2 /* Timer */, name, duration, annotations);
             };
             NamespaceTimer.prototype.start = function (name, annotations) {
-                this.PARTIALS[name] = [timestamp(), annotations];
+                this.PARTIALS[name] = [timeSinceInit(), annotations];
                 return new Timer(this, name);
             };
             NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -306,7 +306,7 @@ define(["require", "exports"], function (require, exports) {
                     logError("Timer " + name + " ended without having been started");
                     return;
                 }
-                duration = timestamp() - this.PARTIALS[name][0];
+                duration = timeSinceInit() - this.PARTIALS[name][0];
                 annotations = extend(annotations, this.PARTIALS[name][1]);
                 this.PARTIALS[name] = false;
                 this.send(name, duration, annotations);
@@ -340,8 +340,12 @@ define(["require", "exports"], function (require, exports) {
                     return self.timeSync(name, action, scope || this, arguments, annotations);
                 };
             };
+            /**
+             * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
+             */
             NamespaceTimer.prototype.mark = function (name, annotations) {
-                this.send(name, timestamp(), annotations);
+                var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
+                this.send(name, time, annotations);
             };
             return NamespaceTimer;
         })();

--- a/dist/weppy.amd.js
+++ b/dist/weppy.amd.js
@@ -13,7 +13,7 @@ define(["require", "exports"], function (require, exports) {
             "page": 'index',
             "context": {},
             "debug": false
-        }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+        }, initTime = (window.performance && window.performance.timing) ? window.performance.timing.navigationStart : +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
             return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
         }, log = function () {
             if (options.debug) {

--- a/dist/weppy.cjs.js
+++ b/dist/weppy.cjs.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+    }, initTime = (window.performance && window.performance.timing) ? window.performance.timing.navigationStart : +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {

--- a/dist/weppy.cjs.js
+++ b/dist/weppy.cjs.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {
@@ -296,7 +296,7 @@ var WeppyImpl;
             this._namespace.send(2 /* Timer */, name, duration, annotations);
         };
         NamespaceTimer.prototype.start = function (name, annotations) {
-            this.PARTIALS[name] = [timestamp(), annotations];
+            this.PARTIALS[name] = [timeSinceInit(), annotations];
             return new Timer(this, name);
         };
         NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -305,7 +305,7 @@ var WeppyImpl;
                 logError("Timer " + name + " ended without having been started");
                 return;
             }
-            duration = timestamp() - this.PARTIALS[name][0];
+            duration = timeSinceInit() - this.PARTIALS[name][0];
             annotations = extend(annotations, this.PARTIALS[name][1]);
             this.PARTIALS[name] = false;
             this.send(name, duration, annotations);
@@ -339,8 +339,12 @@ var WeppyImpl;
                 return self.timeSync(name, action, scope || this, arguments, annotations);
             };
         };
+        /**
+         * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
+         */
         NamespaceTimer.prototype.mark = function (name, annotations) {
-            this.send(name, timestamp(), annotations);
+            var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
+            this.send(name, time, annotations);
         };
         return NamespaceTimer;
     })();

--- a/dist/weppy.cjs.js
+++ b/dist/weppy.cjs.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {
@@ -296,7 +296,7 @@ var WeppyImpl;
             this._namespace.send(2 /* Timer */, name, duration, annotations);
         };
         NamespaceTimer.prototype.start = function (name, annotations) {
-            this.PARTIALS[name] = [timeSinceInit(), annotations];
+            this.PARTIALS[name] = [timestamp(), annotations];
             return new Timer(this, name);
         };
         NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -305,7 +305,7 @@ var WeppyImpl;
                 logError("Timer " + name + " ended without having been started");
                 return;
             }
-            duration = timeSinceInit() - this.PARTIALS[name][0];
+            duration = timestamp() - this.PARTIALS[name][0];
             annotations = extend(annotations, this.PARTIALS[name][1]);
             this.PARTIALS[name] = false;
             this.send(name, duration, annotations);
@@ -339,12 +339,8 @@ var WeppyImpl;
                 return self.timeSync(name, action, scope || this, arguments, annotations);
             };
         };
-        /**
-         * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
-         */
         NamespaceTimer.prototype.mark = function (name, annotations) {
-            var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
-            this.send(name, time, annotations);
+            this.send(name, timestamp(), annotations);
         };
         return NamespaceTimer;
     })();

--- a/dist/weppy.js
+++ b/dist/weppy.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+    }, initTime = (window.performance && window.performance.timing) ? window.performance.timing.navigationStart : +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {

--- a/dist/weppy.js
+++ b/dist/weppy.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {
@@ -296,7 +296,7 @@ var WeppyImpl;
             this._namespace.send(2 /* Timer */, name, duration, annotations);
         };
         NamespaceTimer.prototype.start = function (name, annotations) {
-            this.PARTIALS[name] = [timestamp(), annotations];
+            this.PARTIALS[name] = [timeSinceInit(), annotations];
             return new Timer(this, name);
         };
         NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -305,7 +305,7 @@ var WeppyImpl;
                 logError("Timer " + name + " ended without having been started");
                 return;
             }
-            duration = timestamp() - this.PARTIALS[name][0];
+            duration = timeSinceInit() - this.PARTIALS[name][0];
             annotations = extend(annotations, this.PARTIALS[name][1]);
             this.PARTIALS[name] = false;
             this.send(name, duration, annotations);
@@ -339,8 +339,12 @@ var WeppyImpl;
                 return self.timeSync(name, action, scope || this, arguments, annotations);
             };
         };
+        /**
+         * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
+         */
         NamespaceTimer.prototype.mark = function (name, annotations) {
-            this.send(name, timestamp(), annotations);
+            var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
+            this.send(name, time, annotations);
         };
         return NamespaceTimer;
     })();

--- a/dist/weppy.js
+++ b/dist/weppy.js
@@ -12,7 +12,7 @@ var WeppyImpl;
         "page": 'index',
         "context": {},
         "debug": false
-    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timeSinceInit = function () {
+    }, initTime = +(new Date), queue, aggregationTimeout, maxTimeout, sentPerformanceData, timestamp = function () {
         return (window.performance && window.performance.now) ? window.performance.now() : (+(new Date) - initTime);
     }, log = function () {
         if (options.debug) {
@@ -296,7 +296,7 @@ var WeppyImpl;
             this._namespace.send(2 /* Timer */, name, duration, annotations);
         };
         NamespaceTimer.prototype.start = function (name, annotations) {
-            this.PARTIALS[name] = [timeSinceInit(), annotations];
+            this.PARTIALS[name] = [timestamp(), annotations];
             return new Timer(this, name);
         };
         NamespaceTimer.prototype.stop = function (name, annotations) {
@@ -305,7 +305,7 @@ var WeppyImpl;
                 logError("Timer " + name + " ended without having been started");
                 return;
             }
-            duration = timeSinceInit() - this.PARTIALS[name][0];
+            duration = timestamp() - this.PARTIALS[name][0];
             annotations = extend(annotations, this.PARTIALS[name][1]);
             this.PARTIALS[name] = false;
             this.send(name, duration, annotations);
@@ -339,12 +339,8 @@ var WeppyImpl;
                 return self.timeSync(name, action, scope || this, arguments, annotations);
             };
         };
-        /**
-         * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
-         */
         NamespaceTimer.prototype.mark = function (name, annotations) {
-            var time = (window.performance && window.performance.timing) ? window.performance.now() : timeSinceInit();
-            this.send(name, time, annotations);
+            this.send(name, timestamp(), annotations);
         };
         return NamespaceTimer;
     })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "weppy",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"description": "Library to collect and report web application performance metrics",
 	"repository": {
 		"type": "git",

--- a/src/weppy.ts
+++ b/src/weppy.ts
@@ -27,7 +27,7 @@ module WeppyImpl {
 		},
 		initTime = +(new Date),
 		queue, aggregationTimeout, maxTimeout, sentPerformanceData,
-		timeSinceInit = () => {
+		timestamp = () => {
 			return (window.performance && window.performance.now)
 				? window.performance.now() : (+(new Date) - initTime);
 		},
@@ -371,7 +371,7 @@ module WeppyImpl {
 		}
 
 		start (name: string, annotations?: WeppyContext) {
-			this.PARTIALS[name] = [timeSinceInit(), annotations];
+			this.PARTIALS[name] = [timestamp(), annotations];
 			return new Timer(this, name);
 		}
 
@@ -381,7 +381,7 @@ module WeppyImpl {
 				logError("Timer " + name + " ended without having been started");
 				return;
 			}
-			duration = timeSinceInit() - this.PARTIALS[name][0];
+			duration = timestamp() - this.PARTIALS[name][0];
 			annotations = extend(annotations, this.PARTIALS[name][1]);
 			this.PARTIALS[name] = false;
 			this.send(name, duration, annotations);
@@ -421,15 +421,8 @@ module WeppyImpl {
 			};
 		}
 
-		/**
-		 * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
-		 */
 		mark (name: string, annotations?: WeppyContext) {
-			var time: number = (window.performance && window.performance.timing ) ?
-				window.performance.now() :
-				timeSinceInit();
-
-			this.send(name, time, annotations);
+			this.send(name, timestamp(), annotations);
 		}
 
 	}

--- a/src/weppy.ts
+++ b/src/weppy.ts
@@ -25,13 +25,14 @@ module WeppyImpl {
 			"context": {},
 			"debug": false
 		},
-		initTime = +(new Date),
+		initTime = (window.performance && window.performance.timing)
+			? window.performance.timing.navigationStart : +(new Date),
 		queue, aggregationTimeout, maxTimeout, sentPerformanceData,
 		timestamp = () => {
 			return (window.performance && window.performance.now)
 				? window.performance.now() : (+(new Date) - initTime);
 		},
-		log: any = function() {
+		log: any = function () {
 			if (options.debug) {
 				if (typeof options.debug === 'function') {
 					options.debug.apply(window, arguments);
@@ -41,9 +42,9 @@ module WeppyImpl {
 				}
 			}
 		},
-		logError: any = function() {
+		logError: any = function () {
 			window.console && window.console.error && window.console.error.apply &&
-				window.console.error.apply(window.console, arguments);
+			window.console.error.apply(window.console, arguments);
 		};
 
 	function round (num: number, precision = options.decimalPrecision): number {
@@ -416,7 +417,7 @@ module WeppyImpl {
 
 		wrap (name: string, action, scope, annotations?: WeppyContext) {
 			var self = this;
-			return function() {
+			return function () {
 				return self.timeSync(name, action, scope || this, arguments, annotations);
 			};
 		}
@@ -442,10 +443,10 @@ module WeppyImpl {
 
 	function bindNamespaceFunction (fn, scope, callWrapNamespace) {
 		return callWrapNamespace ?
-			function() {
+			function () {
 				return wrapNamespaceObject(fn.apply(scope, arguments));
 			} :
-			function() {
+			function () {
 				return fn.apply(scope, arguments);
 			}
 	}

--- a/src/weppy.ts
+++ b/src/weppy.ts
@@ -27,7 +27,7 @@ module WeppyImpl {
 		},
 		initTime = +(new Date),
 		queue, aggregationTimeout, maxTimeout, sentPerformanceData,
-		timestamp = () => {
+		timeSinceInit = () => {
 			return (window.performance && window.performance.now)
 				? window.performance.now() : (+(new Date) - initTime);
 		},
@@ -371,7 +371,7 @@ module WeppyImpl {
 		}
 
 		start (name: string, annotations?: WeppyContext) {
-			this.PARTIALS[name] = [timestamp(), annotations];
+			this.PARTIALS[name] = [timeSinceInit(), annotations];
 			return new Timer(this, name);
 		}
 
@@ -381,7 +381,7 @@ module WeppyImpl {
 				logError("Timer " + name + " ended without having been started");
 				return;
 			}
-			duration = timestamp() - this.PARTIALS[name][0];
+			duration = timeSinceInit() - this.PARTIALS[name][0];
 			annotations = extend(annotations, this.PARTIALS[name][1]);
 			this.PARTIALS[name] = false;
 			this.send(name, duration, annotations);
@@ -421,8 +421,15 @@ module WeppyImpl {
 			};
 		}
 
+		/**
+		 * Tracks time since timing.navigationStart if available, otherwise time since init of this script.
+		 */
 		mark (name: string, annotations?: WeppyContext) {
-			this.send(name, timestamp(), annotations);
+			var time: number = (window.performance && window.performance.timing ) ?
+				window.performance.now() :
+				timeSinceInit();
+
+			this.send(name, time, annotations);
 		}
 
 	}


### PR DESCRIPTION
I was trying to use `mark` and `sendPagePerformance` to compare time to certain events. The problem was that both methods were using different init times. This PR makes the init times consistent so the two methods can be used together. 
